### PR TITLE
Update encoder.js EncodeAttributes and Values

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -76,15 +76,15 @@ function parseTag(obj, tagName, codePage, codePageMapping, currentCodePage) {
 		throw new Error('Token for tag ' + tagSuffix + ' not found');
 	}
 
+	//create tag identifier
+	tagBuffer = Buffer.concat([ new Buffer([tagCode.token | (hasRealAttributes ? 128 : 0) | (hasContent? 64 : 0)]) ]);
+
 	if (tagCodePage !== currentCodePage) {
 		//switch code page
-		tagBuffer = new Buffer([SWITCH_PAGE_TOKEN, tagCodePage]);
+		tagBuffer = Buffer.concat([tagBuffer, new Buffer([SWITCH_PAGE_TOKEN, tagCodePage])])
 		currentCodePage = tagCodePage;
 	}
-
-	//create tag identifier
-	tagBuffer = Buffer.concat([ tagBuffer, new Buffer([tagCode.token | (hasRealAttributes ? 128 : 0) | (hasContent? 64 : 0)]) ]);
-
+	
 	//add attributes: According to the pdfs, attributes should be encoded before content, thats why I didnt use the tag content loop
 	if(hasRealAttributes){
 		Object.keys(obj).forEach(function(key) {
@@ -123,9 +123,15 @@ function parseTag(obj, tagName, codePage, codePageMapping, currentCodePage) {
 			});
 		}
 	}
-
+	//Only add END_TOKEN if it has content
+	let returnBuffer
+	if(hasContent){
+		returnBuffer= Buffer.concat([ tagBuffer, new Buffer([END_TOKEN]) ])
+	} else {
+		returnBuffer = Buffer.concat([tagBuffer])
+	}
 	return {
-		buffer: Buffer.concat([ tagBuffer, new Buffer([END_TOKEN]) ]),
+		buffer: returnBuffer,
 		codePage: currentCodePage
 	};
 }
@@ -166,7 +172,8 @@ function parseAttributes(codePage, tagCodePage, obj){
 			attributesBuffer = Buffer.concat([ attributesBuffer, parseAttributeValue(codePage, tagCodePage, selectedAttribute, obj) ])
 		}
 	})
-	return attributesBuffer
+	// return attributesBuffer with end of attribute list
+	return Buffer.concat([attributesBuffer, new Buffer([END_TOKEN])  ])
 }
 /**
 * Incase there's a prefix, we remove it from the tag's value before parsing it

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -48,8 +48,9 @@ function parseTag(obj, tagName, codePage, codePageMapping, currentCodePage) {
 		proto = Object.prototype.toString.call(obj),
 		hasAttributes = !!obj['$'],
 		hasRealAttributes = null,
-		hasContent = (proto === '[object Object]' && Object.keys(obj).length !== 0 && Object.keys(obj) !== ['$']) ||
-					(proto === '[object String]');
+	    	//Previous array comparison was not working
+		hasContent = (proto === '[object Object]' && Object.keys(obj).length !== 0 && Object.keys(obj).toString() !== "$") ||
+				(proto === '[object String]' && obj.length>0);
 
 	//update code page mapping
 	if (hasAttributes) {
@@ -84,7 +85,14 @@ function parseTag(obj, tagName, codePage, codePageMapping, currentCodePage) {
 	//create tag identifier
 	tagBuffer = Buffer.concat([ tagBuffer, new Buffer([tagCode.token | (hasRealAttributes ? 128 : 0) | (hasContent? 64 : 0)]) ]);
 
-	//TODO: add attributes
+	//add attributes: According to the pdfs, attributes should be encoded before content, thats why I didnt use the tag content loop
+	if(hasRealAttributes){
+		Object.keys(obj).forEach(function(key) {
+			if (key === '$') {
+				tagBuffer = Buffer.concat([ tagBuffer, parseAttributes(codePage, tagCodePage, obj[key]) ]);
+			}
+		})
+	}
 
 	//tag content
 	if (hasContent) {
@@ -137,6 +145,65 @@ function createInlineString(str) {
 		new Buffer(str),
 		new Buffer([INLINE_STR_END_TOKEN])
 	]);
+}
+/**
+* Parses the attributes looking in the pages attribute entry.
+* More than 1 attribute can exist depending on the prefix, by default we grab the empty prefix attribute but we seek in case the prefix matches
+*/
+function parseAttributes(codePage, tagCodePage, obj){
+	var attributesBuffer = new Buffer('')
+	Object.keys(obj).forEach(function(key) {
+		var tagsAttribute = codePage.findAttributes(tagCodePage, key);
+		if (tagsAttribute){
+			var selectedAttribute = tagsAttribute.filter((elem) => { return typeof elem.prefix === 'undefined'})[0]
+			for (var i = 0; i < tagsAttribute.length; i++) {
+				if (tagsAttribute[i].prefix && obj[key].startsWith(tagsAttribute[i].prefix)){
+					selectedAttribute = tagsAttribute[i]
+					break;
+				}
+			}
+			attributesBuffer = Buffer.concat([ attributesBuffer, new Buffer([selectedAttribute.token]) ])
+			attributesBuffer = Buffer.concat([ attributesBuffer, parseAttributeValue(codePage, tagCodePage, selectedAttribute, obj) ])
+		}
+	})
+	return attributesBuffer
+}
+/**
+* Incase there's a prefix, we remove it from the tag's value before parsing it
+*/
+function parseAttributeValue(codePage, tagCodePage, tagAttribute, obj){
+	let valueBuf =  parseValue(new Buffer(0), codePage, tagCodePage, obj[tagAttribute.name].replace(tagAttribute.prefix, ''))
+	return valueBuf
+}
+
+/**
+* Recursive function to parse the attributes value searching coded values in the values entry of the codePage.
+* In the advanced example: http://abc.org/s would be encoded as: 
+* 	http:// ->part of the prefix, so we remove it on the parseAttributeValue function
+*	abc 	-> encoded as an inlinestring
+*	.org	-> encoded as a defined value 0x85
+*	/s	-> encoded as an inlinestring
+*/
+function parseValue(valueBuffer, codePage, tagCodePage, realValue){
+	if(!realValue) return new Buffer(0)
+	else {
+		var minIndexValue = codePage.findMinIndexValue(tagCodePage, realValue)
+		if (!minIndexValue){
+			return createInlineString(realValue)
+		}
+		else {
+			let buf1, buf2
+			if(minIndexValue.index>0){
+				buf1 = createInlineString(realValue.substr(0,minIndexValue.index))
+				buf2 = parseValue(valueBuffer, codePage, tagCodePage, realValue.substr(minIndexValue.index, realValue.length))
+			} else {
+				buf1 = new Buffer([minIndexValue.value.token])
+				buf2 = parseValue(valueBuffer, codePage, tagCodePage, realValue.replace(minIndexValue.value.name, ''))
+			}
+			valueBuffer = Buffer.concat([valueBuffer, buf1, buf2])
+			return valueBuffer
+		}
+	}
 }
 
 function updateCodePageMapping(codePage, codePageMapping, attributes) {


### PR DESCRIPTION
Hi! this pull request encodes the attributes, with prefix and defined values.
The codePage should have those new entries if desired (note attributes and values arrays and prefix field in the attribute objects)

```
{
    name: 'test2',
    tags: [
        { name: 'CARD', token: 0x05 },
        { name: 'INPUT', token: 0x06 },
        { name: 'XYZ', token: 0x07 },
        { name: 'DO', token: 0x08 }
    ],
    attributes: [
        //ATTRIBUTES
        { name: 'STYLE', prefix: 'LIST', token: 0x05 },
        { name: 'TYPE', token: 0x06 },
        { name: 'TYPE', prefix: 'TEXT', token: 0x07 },
        { name: 'URL', prefix: 'http://', token: 0x08 },
        { name: 'NAME', token: 0x09 },
        { name: 'KEY', token: 0x0A }
    ],
    values: [
        //ATTRIBUTE values
        { name: '.org', token: 0x85 },
        { name: 'ACCEPT', token: 0x86 }
    ]
}
```
